### PR TITLE
Make the ModalBarrier not dismissible when barrierEnabled is true

### DIFF
--- a/lib/flutter_progress_hud.dart
+++ b/lib/flutter_progress_hud.dart
@@ -115,6 +115,7 @@ class _ProgressHUDState extends State<ProgressHUD>
           visible: _barrierVisible,
           child: ModalBarrier(
             color: widget.barrierColor,
+            dismissible: false,
           ),
         ),
       );


### PR DESCRIPTION
Related issue: https://github.com/FlorinMihalache/flutter_progress_hud/issues/5

The `ModalBarrier` that is shown when `barrierEnabled` is true has a `dismissible` value that defaults to `true`. This means the `ModalBarrier` can still be dismissed even though the barrier is enabled. 

Approach 1: This PR sets the `dismissible` value to false so the `ModalBarrier` cannot be dismissed.


Approach 2:  

If it is the intention of the author to leave `dismissible` as `true`, another way to solve the issue is to make the following change:

```
// https://github.com/FlorinMihalache/flutter_progress_hud/blob/master/lib/flutter_progress_hud.dart#L128
IgnorePointer(
   ignoring: widget.barrierEnabled || !_isShow,
   ...
```

Approach 1 seems preferable because it is slightly counter-intuitive if the `ModalBarrier` can be dismissed even though `barrierEnabled` is `true`.